### PR TITLE
Proof of concept fix for Flax LCM PR

### DIFF
--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -89,7 +89,7 @@ def is_compiled_module(module) -> bool:
     return isinstance(module, torch._dynamo.eval_frame.OptimizedModule)
 
 
-def fourier_filter(x_in: torch.Tensor, threshold: int, scale: int) -> torch.Tensor:
+def fourier_filter(x_in: "torch.Tensor", threshold: int, scale: int) -> "torch.Tensor":
     """Fourier filter as introduced in FreeU (https://arxiv.org/abs/2309.11497).
 
     This version of the method comes from here:
@@ -121,8 +121,8 @@ def fourier_filter(x_in: torch.Tensor, threshold: int, scale: int) -> torch.Tens
 
 
 def apply_freeu(
-    resolution_idx: int, hidden_states: torch.Tensor, res_hidden_states: torch.Tensor, **freeu_kwargs
-) -> Tuple[torch.Tensor, torch.Tensor]:
+    resolution_idx: int, hidden_states: "torch.Tensor", res_hidden_states: "torch.Tensor", **freeu_kwargs
+) -> Tuple["torch.Tensor", "torch.Tensor"]:
     """Applies the FreeU mechanism as introduced in https:
     //arxiv.org/abs/2309.11497. Adapted from the official code repository: https://github.com/ChenyangSi/FreeU.
 


### PR DESCRIPTION
Splitting the key makes the denoising loop work without the artifacts previously observed.

This is not meant to be the final solution, but a proof-of-concept demonstration. I'm not keen on introducing RNG Key management at the pipeline level; instead, I wonder if we could set the key as part of the scheduler state and have the scheduler manage it. In any case, I suggest to merge this in the in-progress PR and move the discussion there.

Note also that I believe the solution in [`FlaxDDPMScheduler` is wrong](https://github.com/huggingface/diffusers/blob/774f5c45817805546ae5eb914c175d4fe72dcfe9/src/diffusers/schedulers/scheduling_ddpm_flax.py#L267), as it will always generate the same random variance every time the function is called. We do need to carry the RNG state.

I have tested with [`DEBUG`](https://github.com/entrpn/diffusers/blob/0f55c17e1742aee3e34e419c6856d044746a1fd0/src/diffusers/pipelines/stable_diffusion_xl/pipeline_flax_stable_diffusion_xl.py#L39) `True` and `False`, but without jitting the pipeline.

(Commit 7e0a0cd2 is unrelated, sorry; it's already in main #6272)